### PR TITLE
Change SQL for integer fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Upcoming
+
+* Fix `cast`ing bug when sending negative values to integer fields.
+
 ## v0.6.0
 
 * Add `EmailPGPPublicKeyField` and `EmailPGPSymmetricKeyField`.

--- a/pgcrypto_fields/__init__.py
+++ b/pgcrypto_fields/__init__.py
@@ -4,7 +4,12 @@ from django.conf import settings
 DIGEST_SQL = "digest(%s, 'sha512')"
 HMAC_SQL = "hmac(%s, '{}', 'sha512')".format(settings.PGCRYPTO_KEY)
 
-PGP_PUB_ENCRYPT_SQL = "pgp_pub_encrypt(%s::text, dearmor('{}'))".format(
+INTEGER_PGP_PUB_ENCRYPT_SQL = "pgp_pub_encrypt('%s', dearmor('{}'))".format(
     settings.PUBLIC_PGP_KEY,
 )
-PGP_SYM_ENCRYPT_SQL = "pgp_sym_encrypt(%s::text, '{}')".format(settings.PGCRYPTO_KEY)
+INTEGER_PGP_SYM_ENCRYPT_SQL = "pgp_sym_encrypt('%s', '{}')".format(settings.PGCRYPTO_KEY)
+
+PGP_PUB_ENCRYPT_SQL = "pgp_pub_encrypt(%s, dearmor('{}'))".format(
+    settings.PUBLIC_PGP_KEY,
+)
+PGP_SYM_ENCRYPT_SQL = "pgp_sym_encrypt(%s, '{}')".format(settings.PGCRYPTO_KEY)

--- a/pgcrypto_fields/fields.py
+++ b/pgcrypto_fields/fields.py
@@ -3,6 +3,8 @@ from django.db import models
 from pgcrypto_fields import (
     DIGEST_SQL,
     HMAC_SQL,
+    INTEGER_PGP_PUB_ENCRYPT_SQL,
+    INTEGER_PGP_SYM_ENCRYPT_SQL,
     PGP_PUB_ENCRYPT_SQL,
     PGP_SYM_ENCRYPT_SQL,
 )
@@ -80,35 +82,39 @@ TextHMACField.register_lookup(HMACLookup)
 
 class PGPPublicKeyFieldMixin(PGPMixin):
     """PGP public key encrypted field mixin for postgres."""
-    encrypt_sql = PGP_PUB_ENCRYPT_SQL
     aggregate = PGPPublicKeyAggregate
 
 
 class PGPSymmetricKeyFieldMixin(PGPMixin):
     """PGP symmetric key encrypted field mixin for postgred."""
-    encrypt_sql = PGP_SYM_ENCRYPT_SQL
     aggregate = PGPSymmetricKeyAggregate
 
 
 class EmailPGPPublicKeyField(PGPPublicKeyFieldMixin, models.EmailField):
     """Email PGP public key encrypted field."""
+    encrypt_sql = PGP_PUB_ENCRYPT_SQL
 
 
 class IntegerPGPPublicKeyField(PGPPublicKeyFieldMixin, models.IntegerField):
     """Integer PGP public key encrypted field."""
+    encrypt_sql = INTEGER_PGP_PUB_ENCRYPT_SQL
 
 
 class TextPGPPublicKeyField(PGPPublicKeyFieldMixin, models.TextField):
     """Text PGP public key encrypted field."""
+    encrypt_sql = PGP_PUB_ENCRYPT_SQL
 
 
 class EmailPGPSymmetricKeyField(PGPSymmetricKeyFieldMixin, models.EmailField):
     """Email PGP symmetric key encrypted field."""
+    encrypt_sql = PGP_SYM_ENCRYPT_SQL
 
 
 class IntegerPGPSymmetricKeyField(PGPSymmetricKeyFieldMixin, models.IntegerField):
     """Integer PGP symmetric key encrypted field."""
+    encrypt_sql = INTEGER_PGP_SYM_ENCRYPT_SQL
 
 
 class TextPGPSymmetricKeyField(PGPSymmetricKeyFieldMixin, models.TextField):
     """Text PGP symmetric key encrypted field for postgres."""
+    encrypt_sql = PGP_SYM_ENCRYPT_SQL

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -238,12 +238,16 @@ class TestEncryptedTextFieldModel(TestCase):
         )
         self.assertEqual(updated_instance.first(), instance)
 
-    def test_negative_number(self):
-        """Assert negative number can be saved."""
+    def test_pgp_public_key_negative_number(self):
+        """Assert negative value is saved with an `IntegerPGPPublicKeyField` field."""
         expected = -1
-        instance = EncryptedTextFieldModelFactory.create(
-            integer_pgp_pub_field=expected,
-            integer_pgp_sym_field=expected,
-        )
+        instance = EncryptedTextFieldModelFactory.create(integer_pgp_pub_field=expected)
+
         self.assertEqual(instance.integer_pgp_pub_field, expected)
+
+    def test_pgp_symmetric_key_negative_number(self):
+        """Assert negative value is saved with an `IntegerPGPSymmetricKeyField` field."""
+        expected = -1
+        instance = EncryptedTextFieldModelFactory.create(integer_pgp_sym_field=expected)
+
         self.assertEqual(instance.integer_pgp_sym_field, expected)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -237,3 +237,13 @@ class TestEncryptedTextFieldModel(TestCase):
             hmac_field__hash_of=expected,
         )
         self.assertEqual(updated_instance.first(), instance)
+
+    def test_negative_number(self):
+        """Assert negative number can be saved."""
+        expected = -1
+        instance = EncryptedTextFieldModelFactory.create(
+            integer_pgp_pub_field=expected,
+            integer_pgp_sym_field=expected,
+        )
+        self.assertEqual(instance.integer_pgp_pub_field, expected)
+        self.assertEqual(instance.integer_pgp_sym_field, expected)


### PR DESCRIPTION
Sending negative values to Integer values produces a `ProgrammingError`.

```
LINE 42: ..."integer_field" = pgp_pub_encrypt( -1::text, ...
                                                              ^
HINT:  No operator matches the given name and argument type(s). You might need to add explicit type casts.)
```