### PR TITLE
Allow NULL values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Upcoming
+
+* Allow `NULL` values for:
+  `TextDigestField`;
+  `TextHMACField`;
+  `IntegerPGPPublicKeyField`;
+  `IntegerPGPSymmetricKeyField`.
+
 ## v0.6.1
 
 * Fix `cast`ing bug when sending negative values to integer fields.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 ## Upcoming
 
-* Allow `NULL` values for:
+* Allow/check `NULL` values for:
   `TextDigestField`;
   `TextHMACField`;
+  `EmailPGPPublicKeyField`;
   `IntegerPGPPublicKeyField`;
+  `TextPGPPublicKeyField`;
+  `EmailPGPSymmetricKeyField`.
   `IntegerPGPSymmetricKeyField`.
+  `TextPGPSymmetricKeyField`.
 
 ## v0.6.1
 

--- a/pgcrypto_fields/__init__.py
+++ b/pgcrypto_fields/__init__.py
@@ -1,13 +1,18 @@
 from django.conf import settings
 
 
+CAST_TO_TEXT = "nullif(%s, NULL)::text"
 DIGEST_SQL = "digest(%s, 'sha512')"
 HMAC_SQL = "hmac(%s, '{}', 'sha512')".format(settings.PGCRYPTO_KEY)
 
-INTEGER_PGP_PUB_ENCRYPT_SQL = "pgp_pub_encrypt('%s', dearmor('{}'))".format(
+INTEGER_PGP_PUB_ENCRYPT_SQL = "pgp_pub_encrypt({}, dearmor('{}'))".format(
+    CAST_TO_TEXT,
     settings.PUBLIC_PGP_KEY,
 )
-INTEGER_PGP_SYM_ENCRYPT_SQL = "pgp_sym_encrypt('%s', '{}')".format(settings.PGCRYPTO_KEY)
+INTEGER_PGP_SYM_ENCRYPT_SQL = "pgp_sym_encrypt({}, '{}')".format(
+    CAST_TO_TEXT,
+    settings.PGCRYPTO_KEY,
+)
 
 PGP_PUB_ENCRYPT_SQL = "pgp_pub_encrypt(%s, dearmor('{}'))".format(
     settings.PUBLIC_PGP_KEY,

--- a/pgcrypto_fields/fields.py
+++ b/pgcrypto_fields/fields.py
@@ -63,7 +63,7 @@ class TextFieldHash(models.TextField):
 
         `connection` is ignored here as we don't need custom operators.
         """
-        if value.startswith('\\x'):
+        if value is None or value.startswith('\\x'):
             return '%s'
         return self.encrypt_sql
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,17 +1,20 @@
 import factory
 
-from .models import EncryptedTextFieldModel
+from .models import EncryptedModel
 
 
-class EncryptedTextFieldModelFactory(factory.DjangoModelFactory):
+class EncryptedModelFactory(factory.DjangoModelFactory):
     """Factory to generate hashed and encrypted data."""
     class Meta:
-        model = EncryptedTextFieldModel
+        model = EncryptedModel
 
     digest_field = factory.Sequence('Text digest {}'.format)
     hmac_field = factory.Sequence('Text hmac {}'.format)
 
+    email_pgp_pub_field = factory.Sequence('email{}@public.key'.format)
     integer_pgp_pub_field = 42
     pgp_pub_field = factory.Sequence('Text with public key {}'.format)
+
+    email_pgp_sym_field = factory.Sequence('email{}@symmetric.key'.format)
     integer_pgp_sym_field = 43
     pgp_sym_field = factory.Sequence('Text with symmetric key {}'.format)

--- a/tests/models.py
+++ b/tests/models.py
@@ -3,15 +3,15 @@ from django.db import models
 from pgcrypto_fields import fields
 
 
-class EncryptedTextFieldModel(models.Model):
-    """Dummy model used for tests to check `EncryptedTextField`."""
-    digest_field = fields.TextDigestField()
-    hmac_field = fields.TextHMACField()
+class EncryptedModel(models.Model):
+    """Dummy model used for tests to check the fields."""
+    digest_field = fields.TextDigestField(blank=True, null=True)
+    hmac_field = fields.TextHMACField(blank=True, null=True)
 
-    email_pgp_pub_field = fields.EmailPGPPublicKeyField()
-    integer_pgp_pub_field = fields.IntegerPGPPublicKeyField()
-    pgp_pub_field = fields.TextPGPPublicKeyField()
+    email_pgp_pub_field = fields.EmailPGPPublicKeyField(blank=True, null=True)
+    integer_pgp_pub_field = fields.IntegerPGPPublicKeyField(blank=True, null=True)
+    pgp_pub_field = fields.TextPGPPublicKeyField(blank=True, null=True)
 
-    email_pgp_sym_field = fields.EmailPGPSymmetricKeyField()
-    integer_pgp_sym_field = fields.IntegerPGPSymmetricKeyField()
-    pgp_sym_field = fields.TextPGPSymmetricKeyField()
+    email_pgp_sym_field = fields.EmailPGPSymmetricKeyField(blank=True, null=True)
+    integer_pgp_sym_field = fields.IntegerPGPSymmetricKeyField(blank=True, null=True)
+    pgp_sym_field = fields.TextPGPSymmetricKeyField(blank=True, null=True)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -3,8 +3,8 @@ from django.test import TestCase
 from pgcrypto_fields import aggregates, proxy
 from pgcrypto_fields.fields import PGPMixin, TextFieldHash
 
-from .factories import EncryptedTextFieldModelFactory
-from .models import EncryptedTextFieldModel
+from .factories import EncryptedModelFactory
+from .models import EncryptedModel
 
 
 class TestTextFieldHash(TestCase):
@@ -28,7 +28,7 @@ class TestPGPMixin(TestCase):
 
 class TestEncryptedTextFieldModel(TestCase):
     """Test `EncryptedTextField` can be integrated in a `Django` model."""
-    model = EncryptedTextFieldModel
+    model = EncryptedModel
 
     def test_fields(self):
         """Assert fields are representing our model."""
@@ -48,7 +48,7 @@ class TestEncryptedTextFieldModel(TestCase):
 
     def test_value_returned_is_not_bytea(self):
         """Assert value returned is not a memoryview instance."""
-        EncryptedTextFieldModelFactory.create()
+        EncryptedModelFactory.create()
 
         instance = self.model.objects.get()
         self.assertIsInstance(instance.digest_field, str)
@@ -76,7 +76,7 @@ class TestEncryptedTextFieldModel(TestCase):
     def test_value_query(self):
         """Assert querying the field's value is making one query."""
         expected = 'bonjour'
-        EncryptedTextFieldModelFactory.create(pgp_pub_field=expected)
+        EncryptedModelFactory.create(pgp_pub_field=expected)
 
         instance = self.model.objects.get()
 
@@ -86,7 +86,7 @@ class TestEncryptedTextFieldModel(TestCase):
     def test_value_pgp_pub(self):
         """Assert we can get back the decrypted value."""
         expected = 'bonjour'
-        EncryptedTextFieldModelFactory.create(pgp_pub_field=expected)
+        EncryptedModelFactory.create(pgp_pub_field=expected)
 
         instance = self.model.objects.get()
         value = instance.pgp_pub_field
@@ -96,8 +96,8 @@ class TestEncryptedTextFieldModel(TestCase):
     def test_value_pgp_pub_multipe(self):
         """Assert we get back the correct value when the table contains data."""
         expected = 'bonjour'
-        EncryptedTextFieldModelFactory.create(pgp_pub_field='au revoir')
-        created = EncryptedTextFieldModelFactory.create(pgp_pub_field=expected)
+        EncryptedModelFactory.create(pgp_pub_field='au revoir')
+        created = EncryptedModelFactory.create(pgp_pub_field=expected)
 
         instance = self.model.objects.get(pk=created.pk)
         value = instance.pgp_pub_field
@@ -107,7 +107,7 @@ class TestEncryptedTextFieldModel(TestCase):
     def test_value_pgp_sym(self):
         """Assert we can get back the decrypted value."""
         expected = 'bonjour'
-        EncryptedTextFieldModelFactory.create(pgp_sym_field=expected)
+        EncryptedModelFactory.create(pgp_sym_field=expected)
 
         instance = self.model.objects.get()
         value = instance.pgp_sym_field
@@ -117,14 +117,14 @@ class TestEncryptedTextFieldModel(TestCase):
     def test_instance_not_saved(self):
         """Assert not saved instance return the value to be encrypted."""
         expected = 'bonjour'
-        instance = EncryptedTextFieldModelFactory.build(pgp_pub_field=expected)
+        instance = EncryptedModelFactory.build(pgp_pub_field=expected)
         self.assertEqual(instance.pgp_pub_field, expected)
         self.assertEqual(instance.pgp_pub_field, expected)
 
     def test_decrypt_annotate(self):
         """Assert we can get back the decrypted value."""
         expected = 'bonjour'
-        EncryptedTextFieldModelFactory.create(
+        EncryptedModelFactory.create(
             pgp_pub_field=expected,
             pgp_sym_field=expected,
         )
@@ -140,7 +140,7 @@ class TestEncryptedTextFieldModel(TestCase):
     def test_decrypt_filter(self):
         """Assert we can get filter the decrypted value."""
         expected = 'bonjour'
-        EncryptedTextFieldModelFactory.create(
+        EncryptedModelFactory.create(
             pgp_pub_field=expected,
         )
 
@@ -153,31 +153,31 @@ class TestEncryptedTextFieldModel(TestCase):
     def test_digest_lookup(self):
         """Assert we can filter a digest value."""
         value = 'bonjour'
-        expected = EncryptedTextFieldModelFactory.create(digest_field=value)
-        EncryptedTextFieldModelFactory.create()
+        expected = EncryptedModelFactory.create(digest_field=value)
+        EncryptedModelFactory.create()
 
-        queryset = EncryptedTextFieldModel.objects.filter(digest_field__hash_of=value)
+        queryset = EncryptedModel.objects.filter(digest_field__hash_of=value)
 
         self.assertCountEqual(queryset, [expected])
 
     def test_hmac_lookup(self):
         """Assert we can filter a digest value."""
         value = 'bonjour'
-        expected = EncryptedTextFieldModelFactory.create(hmac_field=value)
-        EncryptedTextFieldModelFactory.create()
+        expected = EncryptedModelFactory.create(hmac_field=value)
+        EncryptedModelFactory.create()
 
-        queryset = EncryptedTextFieldModel.objects.filter(hmac_field__hash_of=value)
+        queryset = EncryptedModel.objects.filter(hmac_field__hash_of=value)
         self.assertCountEqual(queryset, [expected])
 
     def test_default_lookup(self):
         """Assert default lookup can be called."""
-        queryset = EncryptedTextFieldModel.objects.filter(hmac_field__isnull=True)
+        queryset = EncryptedModel.objects.filter(hmac_field__isnull=True)
         self.assertFalse(queryset)
 
     def test_update_attribute_digest_field(self):
         """Assert digest field can be updated through its attribute on the model."""
         expected = 'bonjour'
-        instance = EncryptedTextFieldModelFactory.create()
+        instance = EncryptedModelFactory.create()
         instance.digest_field = expected
         instance.save()
 
@@ -187,7 +187,7 @@ class TestEncryptedTextFieldModel(TestCase):
     def test_update_attribute_hmac_field(self):
         """Assert hmac field can be updated through its attribute on the model."""
         expected = 'bonjour'
-        instance = EncryptedTextFieldModelFactory.create()
+        instance = EncryptedModelFactory.create()
         instance.hmac_field = expected
         instance.save()
 
@@ -197,7 +197,7 @@ class TestEncryptedTextFieldModel(TestCase):
     def test_update_attribute_pgp_pub_field(self):
         """Assert pgp field can be updated through its attribute on the model."""
         expected = 'bonjour'
-        instance = EncryptedTextFieldModelFactory.create()
+        instance = EncryptedModelFactory.create()
         instance.pgp_pub_field = expected
         instance.save()
 
@@ -207,7 +207,7 @@ class TestEncryptedTextFieldModel(TestCase):
     def test_update_attribute_pgp_sym_field(self):
         """Assert pgp field can be updated through its attribute on the model."""
         expected = 'bonjour'
-        instance = EncryptedTextFieldModelFactory.create()
+        instance = EncryptedModelFactory.create()
         instance.pgp_sym_field = expected
         instance.save()
 
@@ -219,7 +219,7 @@ class TestEncryptedTextFieldModel(TestCase):
         expected = 'initial value'
         new_value = 'new_value'
 
-        instance = EncryptedTextFieldModelFactory.create(
+        instance = EncryptedModelFactory.create(
             pgp_pub_field=expected,
             pgp_sym_field=expected,
             digest_field=expected,
@@ -241,13 +241,33 @@ class TestEncryptedTextFieldModel(TestCase):
     def test_pgp_public_key_negative_number(self):
         """Assert negative value is saved with an `IntegerPGPPublicKeyField` field."""
         expected = -1
-        instance = EncryptedTextFieldModelFactory.create(integer_pgp_pub_field=expected)
+        instance = EncryptedModelFactory.create(integer_pgp_pub_field=expected)
 
         self.assertEqual(instance.integer_pgp_pub_field, expected)
 
     def test_pgp_symmetric_key_negative_number(self):
         """Assert negative value is saved with an `IntegerPGPSymmetricKeyField` field."""
         expected = -1
-        instance = EncryptedTextFieldModelFactory.create(integer_pgp_sym_field=expected)
+        instance = EncryptedModelFactory.create(integer_pgp_sym_field=expected)
 
         self.assertEqual(instance.integer_pgp_sym_field, expected)
+
+    def test_digest_null(self):
+        """Assert `NULL` values are saved with a `TextDigestField` field."""
+        instance = EncryptedModel.objects.create()
+        self.assertEqual(instance.integer_pgp_pub_field, None)
+
+    def test_hmac_null(self):
+        """Assert `NULL` values are saved with an `TextHMACField` field."""
+        instance = EncryptedModel.objects.create()
+        self.assertEqual(instance.integer_pgp_sym_field, None)
+
+    def test_integer_pgp_public_key_null(self):
+        """Assert `NULL` values are saved with an `IntegerPGPPublicKeyField` field."""
+        instance = EncryptedModel.objects.create()
+        self.assertEqual(instance.integer_pgp_pub_field, None)
+
+    def test_integer_pgp_symmetric_key_null(self):
+        """Assert `NULL` values are saved with an `IntegerPGPSymmetricKeyField` field."""
+        instance = EncryptedModel.objects.create()
+        self.assertEqual(instance.integer_pgp_sym_field, None)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -262,12 +262,32 @@ class TestEncryptedTextFieldModel(TestCase):
         instance = EncryptedModel.objects.create()
         self.assertEqual(instance.integer_pgp_sym_field, None)
 
+    def test_email_pgp_public_key_null(self):
+        """Assert `NULL` values are saved with an `EmailPGPPublicKeyField` field."""
+        instance = EncryptedModel.objects.create()
+        self.assertEqual(instance.email_pgp_pub_field, None)
+
     def test_integer_pgp_public_key_null(self):
         """Assert `NULL` values are saved with an `IntegerPGPPublicKeyField` field."""
         instance = EncryptedModel.objects.create()
         self.assertEqual(instance.integer_pgp_pub_field, None)
 
+    def test_text_pgp_public_key_null(self):
+        """Assert `NULL` values are saved with an `TextPGPPublicKeyField` field."""
+        instance = EncryptedModel.objects.create()
+        self.assertEqual(instance.pgp_pub_field, None)
+
+    def test_email_pgp_symmetric_key_null(self):
+        """Assert `NULL` values are saved with an `EmailPGPSymmetricKeyField` field."""
+        instance = EncryptedModel.objects.create()
+        self.assertEqual(instance.email_pgp_sym_field, None)
+
     def test_integer_pgp_symmetric_key_null(self):
         """Assert `NULL` values are saved with an `IntegerPGPSymmetricKeyField` field."""
         instance = EncryptedModel.objects.create()
         self.assertEqual(instance.integer_pgp_sym_field, None)
+
+    def test_text_pgp_symmetric_key_null(self):
+        """Assert `NULL` values are saved with an `TextPGPSymmetricKeyField` field."""
+        instance = EncryptedModel.objects.create()
+        self.assertEqual(instance.pgp_sym_field, None)


### PR DESCRIPTION
When sending `None` (or nothing) to an integer field we get back this error: 
`ValueError: invalid literal for int() with base 10: 'NULL'`