### PR TITLE
Avoid setting `max_length` on PGP fields.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Upcoming
+
+* Avoid setting `max_length` on PGP fields.
+
 ## v0.6.2
 
 * Allow/check `NULL` values for:

--- a/pgcrypto_fields/fields.py
+++ b/pgcrypto_fields/fields.py
@@ -23,6 +23,11 @@ class PGPMixin:
     """
     descriptor_class = EncryptedProxyField
 
+    def __init__(self, *args, **kwargs):
+        """`max_length` should be set to None as encrypted text size is variable."""
+        kwargs['max_length'] = None
+        super().__init__(*args, **kwargs)
+
     def contribute_to_class(self, cls, name, **kwargs):
         """
         Add a decrypted field proxy to the model.
@@ -47,6 +52,10 @@ class PGPMixin:
         `value` and `connection` are ignored here as we don't need custom operators.
         """
         return self.encrypt_sql
+
+    def _check_max_length_attribute(self, **kwargs):
+        """Override `_check_max_length_attribute` to remove check on max_length."""
+        return []
 
 
 class TextFieldHash(models.TextField):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,15 +1,24 @@
 from django.test import TestCase
 
 from pgcrypto_fields import aggregates, proxy
-from pgcrypto_fields.fields import PGPMixin, TextFieldHash
+from pgcrypto_fields import fields
 
 from .factories import EncryptedModelFactory
 from .models import EncryptedModel
 
+PGP_FIELDS = (
+    fields.EmailPGPPublicKeyField,
+    fields.EmailPGPSymmetricKeyField,
+    fields.IntegerPGPPublicKeyField,
+    fields.IntegerPGPSymmetricKeyField,
+    fields.TextPGPPublicKeyField,
+    fields.TextPGPSymmetricKeyField,
+)
+
 
 class TestTextFieldHash(TestCase):
     """Test `TextFieldHash` behave properly."""
-    field = TextFieldHash
+    field = fields.TextFieldHash
 
     def test_get_placeholder(self):
         """Assert `get_placeholder` hash value only once."""
@@ -19,11 +28,24 @@ class TestTextFieldHash(TestCase):
 
 class TestPGPMixin(TestCase):
     """Test `PGPMixin` behave properly."""
-    field = PGPMixin
+
+    def test_check(self):
+        """Assert `max_length` check does not return any error."""
+        for field in PGP_FIELDS:
+            with self.subTest(field=field):
+                self.assertEqual(field(name='field').check(), [])
+
+    def test_max_length(self):
+        """Assert `max_length` is ignored."""
+        for field in PGP_FIELDS:
+            with self.subTest(field=field):
+                self.assertEqual(field(max_length=42).max_length, None)
 
     def test_db_type(self):
         """Check db_type is `bytea`."""
-        self.assertEqual(self.field().db_type(), 'bytea')
+        for field in PGP_FIELDS:
+            with self.subTest(field=field):
+                self.assertEqual(field().db_type(), 'bytea')
 
 
 class TestEncryptedTextFieldModel(TestCase):


### PR DESCRIPTION
`max_length` should be avoided as encrypted fields have a variable size.