### PR TITLE
More validator errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Upcoming
+
+* Remove `MaxLengthValidator` from email fields.
+
 ## v0.6.3
 
 * Avoid setting `max_length` on PGP fields.

--- a/pgcrypto_fields/fields.py
+++ b/pgcrypto_fields/fields.py
@@ -10,6 +10,8 @@ from pgcrypto_fields import (
 )
 from pgcrypto_fields.lookups import DigestLookup, HMACLookup
 from pgcrypto_fields.mixins import (
+    EmailPGPPublicKeyFieldMixin,
+    EmailPGPSymmetricKeyFieldMixin,
     HashMixin,
     PGPPublicKeyFieldMixin,
     PGPSymmetricKeyFieldMixin,
@@ -28,7 +30,7 @@ class TextHMACField(HashMixin, models.TextField):
 TextHMACField.register_lookup(HMACLookup)
 
 
-class EmailPGPPublicKeyField(PGPPublicKeyFieldMixin, models.EmailField):
+class EmailPGPPublicKeyField(EmailPGPPublicKeyFieldMixin, models.EmailField):
     """Email PGP public key encrypted field."""
     encrypt_sql = PGP_PUB_ENCRYPT_SQL
 
@@ -43,7 +45,7 @@ class TextPGPPublicKeyField(PGPPublicKeyFieldMixin, models.TextField):
     encrypt_sql = PGP_PUB_ENCRYPT_SQL
 
 
-class EmailPGPSymmetricKeyField(PGPSymmetricKeyFieldMixin, models.EmailField):
+class EmailPGPSymmetricKeyField(EmailPGPSymmetricKeyFieldMixin, models.EmailField):
     """Email PGP symmetric key encrypted field."""
     encrypt_sql = PGP_SYM_ENCRYPT_SQL
 

--- a/pgcrypto_fields/mixins.py
+++ b/pgcrypto_fields/mixins.py
@@ -7,6 +7,11 @@ from pgcrypto_fields.aggregates import (
 from pgcrypto_fields.proxy import EncryptedProxyField
 
 
+def remove_validators(validators, validator_class):
+    """Exclude `validator_class` instances from `validators` list."""
+    return [v for v in validators if not isinstance(v, validator_class)]
+
+
 class HashMixin:
     """Keyed hash mixin.
 
@@ -83,9 +88,7 @@ class RemoveMaxLengthValidatorMixin:
     def __init__(self, *args, **kwargs):
         """Remove `MaxLengthValidator` in parent's `.__init__`."""
         super().__init__(*args, **kwargs)
-        for validator in self.validators:
-            if isinstance(validator, MaxLengthValidator):
-                self.validators.remove(validator)
+        self.validators = remove_validators(self.validators, MaxLengthValidator)
 
 
 class EmailPGPPublicKeyFieldMixin(PGPPublicKeyFieldMixin, RemoveMaxLengthValidatorMixin):

--- a/pgcrypto_fields/mixins.py
+++ b/pgcrypto_fields/mixins.py
@@ -1,3 +1,5 @@
+from django.core.validators import MaxLengthValidator
+
 from pgcrypto_fields.aggregates import (
     PGPPublicKeyAggregate,
     PGPSymmetricKeyAggregate,
@@ -74,3 +76,22 @@ class PGPPublicKeyFieldMixin(PGPMixin):
 class PGPSymmetricKeyFieldMixin(PGPMixin):
     """PGP symmetric key encrypted field mixin for postgred."""
     aggregate = PGPSymmetricKeyAggregate
+
+
+class RemoveMaxLengthValidatorMixin:
+    """Exclude `MaxLengthValidator` from field validators."""
+    def __init__(self, *args, **kwargs):
+        """Remove `MaxLengthValidator` in parent's `.__init__`."""
+        super().__init__(*args, **kwargs)
+        for validator in self.validators:
+            if isinstance(validator, MaxLengthValidator):
+                self.validators.remove(validator)
+
+
+class EmailPGPPublicKeyFieldMixin(PGPPublicKeyFieldMixin, RemoveMaxLengthValidatorMixin):
+    """Email mixin for PGP public key fields."""
+
+
+class EmailPGPSymmetricKeyFieldMixin(
+        PGPSymmetricKeyFieldMixin, RemoveMaxLengthValidatorMixin):
+    """Email mixin for PGP symmetric key fields."""

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -8,9 +8,8 @@ from .models import EncryptedModel
 
 
 KEYED_FIELDS = (fields.TextDigestField, fields.TextHMACField)
-PGP_FIELDS = (
-    fields.EmailPGPPublicKeyField,
-    fields.EmailPGPSymmetricKeyField,
+EMAIL_PGP_FIELDS = (fields.EmailPGPPublicKeyField, fields.EmailPGPSymmetricKeyField)
+PGP_FIELDS = EMAIL_PGP_FIELDS + (
     fields.IntegerPGPPublicKeyField,
     fields.IntegerPGPSymmetricKeyField,
     fields.TextPGPPublicKeyField,
@@ -20,7 +19,6 @@ PGP_FIELDS = (
 
 class TestTextFieldHash(TestCase):
     """Test hash fields behave properly."""
-
     def test_get_placeholder(self):
         """Assert `get_placeholder` hash value only once."""
         for field in KEYED_FIELDS:
@@ -31,7 +29,6 @@ class TestTextFieldHash(TestCase):
 
 class TestPGPMixin(TestCase):
     """Test `PGPMixin` behave properly."""
-
     def test_check(self):
         """Assert `max_length` check does not return any error."""
         for field in PGP_FIELDS:
@@ -49,6 +46,16 @@ class TestPGPMixin(TestCase):
         for field in PGP_FIELDS:
             with self.subTest(field=field):
                 self.assertEqual(field().db_type(), 'bytea')
+
+
+class TestEmailPGPMixin(TestCase):
+    """Test emails fields behave properly."""
+    def test_max_length_validator(self):
+        """Check `MaxLengthValidator` is not set."""
+        for field in EMAIL_PGP_FIELDS:
+            with self.subTest(field=field):
+                field_validated = field().run_validators(value='value@value.com')
+                self.assertEqual(field_validated, None)
 
 
 class TestEncryptedTextFieldModel(TestCase):


### PR DESCRIPTION
Following #24 it looks like `CharField` appends another `validator` in `__init__`

```python
def __init__(self, *args, **kwargs):
    super(CharField, self).__init__(*args, **kwargs)
    self.validators.append(validators.MaxLengthValidator(self.max_length))
```

see https://github.com/django/django/blob/880d7638cf66ed28a60b62335ccfc5dfd5052937/django/db/models/fields/__init__.py#L1013

As using `max_length` is not relevant to this project we need to exclude this validator from running.