### PR TITLE
Refactor mixins

### DIFF
--- a/pgcrypto_fields/fields.py
+++ b/pgcrypto_fields/fields.py
@@ -8,95 +8,24 @@ from pgcrypto_fields import (
     PGP_PUB_ENCRYPT_SQL,
     PGP_SYM_ENCRYPT_SQL,
 )
-from pgcrypto_fields.aggregates import (
-    PGPPublicKeyAggregate,
-    PGPSymmetricKeyAggregate,
-)
 from pgcrypto_fields.lookups import DigestLookup, HMACLookup
-from pgcrypto_fields.proxy import EncryptedProxyField
+from pgcrypto_fields.mixins import (
+    HashMixin,
+    PGPPublicKeyFieldMixin,
+    PGPSymmetricKeyFieldMixin,
+)
 
 
-class PGPMixin:
-    """PGP encryption for field's value.
-
-    `PGPMixin` uses 'pgcrypto' to encrypt data in a postgres database.
-    """
-    descriptor_class = EncryptedProxyField
-
-    def __init__(self, *args, **kwargs):
-        """`max_length` should be set to None as encrypted text size is variable."""
-        kwargs['max_length'] = None
-        super().__init__(*args, **kwargs)
-
-    def contribute_to_class(self, cls, name, **kwargs):
-        """
-        Add a decrypted field proxy to the model.
-
-        Add to the field model an `EncryptedProxyField` to get the decrypted
-        values of the field.
-
-        The decrypted value can be accessed using the field's name attribute on
-        the model instance.
-        """
-        super().contribute_to_class(cls, name, **kwargs)
-        setattr(cls, self.name, self.descriptor_class(field=self))
-
-    def db_type(self, connection=None):
-        """Value stored in the database is hexadecimal."""
-        return 'bytea'
-
-    def get_placeholder(self, value=None, connection=None):
-        """
-        Tell postgres to encrypt this field using PGP.
-
-        `value` and `connection` are ignored here as we don't need custom operators.
-        """
-        return self.encrypt_sql
-
-    def _check_max_length_attribute(self, **kwargs):
-        """Override `_check_max_length_attribute` to remove check on max_length."""
-        return []
-
-
-class TextFieldHash(models.TextField):
-    """Keyed hash TextField.
-
-    `TextFieldHash` uses 'pgcrypto' to encrypt data in a postgres database.
-    """
-    def get_placeholder(self, value=None, connection=None):
-        """
-        Tell postgres to encrypt this field with a hashing function.
-
-        The `value` string is checked to determine if we need to hash or keep
-        the current value.
-
-        `connection` is ignored here as we don't need custom operators.
-        """
-        if value is None or value.startswith('\\x'):
-            return '%s'
-        return self.encrypt_sql
-
-
-class TextDigestField(TextFieldHash):
+class TextDigestField(HashMixin, models.TextField):
     """Text digest field for postgres."""
     encrypt_sql = DIGEST_SQL
 TextDigestField.register_lookup(DigestLookup)
 
 
-class TextHMACField(TextFieldHash):
+class TextHMACField(HashMixin, models.TextField):
     """Text HMAC field for postgres."""
     encrypt_sql = HMAC_SQL
 TextHMACField.register_lookup(HMACLookup)
-
-
-class PGPPublicKeyFieldMixin(PGPMixin):
-    """PGP public key encrypted field mixin for postgres."""
-    aggregate = PGPPublicKeyAggregate
-
-
-class PGPSymmetricKeyFieldMixin(PGPMixin):
-    """PGP symmetric key encrypted field mixin for postgred."""
-    aggregate = PGPSymmetricKeyAggregate
 
 
 class EmailPGPPublicKeyField(PGPPublicKeyFieldMixin, models.EmailField):

--- a/pgcrypto_fields/mixins.py
+++ b/pgcrypto_fields/mixins.py
@@ -1,0 +1,76 @@
+from pgcrypto_fields.aggregates import (
+    PGPPublicKeyAggregate,
+    PGPSymmetricKeyAggregate,
+)
+from pgcrypto_fields.proxy import EncryptedProxyField
+
+
+class HashMixin:
+    """Keyed hash mixin.
+
+    `HashMixin` uses 'pgcrypto' to encrypt data in a postgres database.
+    """
+    def get_placeholder(self, value=None, connection=None):
+        """
+        Tell postgres to encrypt this field with a hashing function.
+
+        The `value` string is checked to determine if we need to hash or keep
+        the current value.
+
+        `connection` is ignored here as we don't need custom operators.
+        """
+        if value is None or value.startswith('\\x'):
+            return '%s'
+        return self.encrypt_sql
+
+
+class PGPMixin:
+    """PGP encryption for field's value.
+
+    `PGPMixin` uses 'pgcrypto' to encrypt data in a postgres database.
+    """
+    descriptor_class = EncryptedProxyField
+
+    def __init__(self, *args, **kwargs):
+        """`max_length` should be set to None as encrypted text size is variable."""
+        kwargs['max_length'] = None
+        super().__init__(*args, **kwargs)
+
+    def contribute_to_class(self, cls, name, **kwargs):
+        """
+        Add a decrypted field proxy to the model.
+
+        Add to the field model an `EncryptedProxyField` to get the decrypted
+        values of the field.
+
+        The decrypted value can be accessed using the field's name attribute on
+        the model instance.
+        """
+        super().contribute_to_class(cls, name, **kwargs)
+        setattr(cls, self.name, self.descriptor_class(field=self))
+
+    def db_type(self, connection=None):
+        """Value stored in the database is hexadecimal."""
+        return 'bytea'
+
+    def get_placeholder(self, value=None, connection=None):
+        """
+        Tell postgres to encrypt this field using PGP.
+
+        `value` and `connection` are ignored here as we don't need custom operators.
+        """
+        return self.encrypt_sql
+
+    def _check_max_length_attribute(self, **kwargs):
+        """Override `_check_max_length_attribute` to remove check on max_length."""
+        return []
+
+
+class PGPPublicKeyFieldMixin(PGPMixin):
+    """PGP public key encrypted field mixin for postgres."""
+    aggregate = PGPPublicKeyAggregate
+
+
+class PGPSymmetricKeyFieldMixin(PGPMixin):
+    """PGP symmetric key encrypted field mixin for postgred."""
+    aggregate = PGPSymmetricKeyAggregate

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -7,6 +7,7 @@ from .factories import EncryptedModelFactory
 from .models import EncryptedModel
 
 
+KEYED_FIELDS = (fields.TextDigestField, fields.TextHMACField)
 PGP_FIELDS = (
     fields.EmailPGPPublicKeyField,
     fields.EmailPGPSymmetricKeyField,
@@ -18,13 +19,14 @@ PGP_FIELDS = (
 
 
 class TestTextFieldHash(TestCase):
-    """Test `TextFieldHash` behave properly."""
-    field = fields.TextFieldHash
+    """Test hash fields behave properly."""
 
     def test_get_placeholder(self):
         """Assert `get_placeholder` hash value only once."""
-        placeholder = self.field().get_placeholder('\\x')
-        self.assertEqual(placeholder, '%s')
+        for field in KEYED_FIELDS:
+            with self.subTest(field=field):
+                placeholder = field().get_placeholder('\\x')
+                self.assertEqual(placeholder, '%s')
 
 
 class TestPGPMixin(TestCase):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -6,6 +6,7 @@ from pgcrypto_fields import fields
 from .factories import EncryptedModelFactory
 from .models import EncryptedModel
 
+
 PGP_FIELDS = (
     fields.EmailPGPPublicKeyField,
     fields.EmailPGPSymmetricKeyField,

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -274,42 +274,11 @@ class TestEncryptedTextFieldModel(TestCase):
 
         self.assertEqual(instance.integer_pgp_sym_field, expected)
 
-    def test_digest_null(self):
-        """Assert `NULL` values are saved with a `TextDigestField` field."""
+    def test_null(self):
+        """Assert `NULL` values are saved."""
         instance = EncryptedModel.objects.create()
-        self.assertEqual(instance.integer_pgp_pub_field, None)
-
-    def test_hmac_null(self):
-        """Assert `NULL` values are saved with an `TextHMACField` field."""
-        instance = EncryptedModel.objects.create()
-        self.assertEqual(instance.integer_pgp_sym_field, None)
-
-    def test_email_pgp_public_key_null(self):
-        """Assert `NULL` values are saved with an `EmailPGPPublicKeyField` field."""
-        instance = EncryptedModel.objects.create()
-        self.assertEqual(instance.email_pgp_pub_field, None)
-
-    def test_integer_pgp_public_key_null(self):
-        """Assert `NULL` values are saved with an `IntegerPGPPublicKeyField` field."""
-        instance = EncryptedModel.objects.create()
-        self.assertEqual(instance.integer_pgp_pub_field, None)
-
-    def test_text_pgp_public_key_null(self):
-        """Assert `NULL` values are saved with an `TextPGPPublicKeyField` field."""
-        instance = EncryptedModel.objects.create()
-        self.assertEqual(instance.pgp_pub_field, None)
-
-    def test_email_pgp_symmetric_key_null(self):
-        """Assert `NULL` values are saved with an `EmailPGPSymmetricKeyField` field."""
-        instance = EncryptedModel.objects.create()
-        self.assertEqual(instance.email_pgp_sym_field, None)
-
-    def test_integer_pgp_symmetric_key_null(self):
-        """Assert `NULL` values are saved with an `IntegerPGPSymmetricKeyField` field."""
-        instance = EncryptedModel.objects.create()
-        self.assertEqual(instance.integer_pgp_sym_field, None)
-
-    def test_text_pgp_symmetric_key_null(self):
-        """Assert `NULL` values are saved with an `TextPGPSymmetricKeyField` field."""
-        instance = EncryptedModel.objects.create()
-        self.assertEqual(instance.pgp_sym_field, None)
+        fields = self.model._meta.get_all_field_names()
+        fields.remove('id')
+        for field in fields:
+            with self.subTest(field=field):
+                self.assertEqual(getattr(instance, field), None)


### PR DESCRIPTION
Separating mixins from `pgcrypto_fields.fields` would make the code easier to
explore.