### PR TITLE
Fix import for Aggregate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Upcoming
+
+* Fix buggy import to `Aggregate` (it affects Django 1.8 which is not supported yet)
+
 ## v0.6.4
 
 * Remove `MaxLengthValidator` from email fields.

--- a/pgcrypto_fields/aggregates.py
+++ b/pgcrypto_fields/aggregates.py
@@ -1,8 +1,9 @@
 from django.conf import settings
 from django.db import models
+from django.db.models.sql.aggregates import Aggregate
 
 
-class PGPPublicKeySQL(models.sql.aggregates.Aggregate):
+class PGPPublicKeySQL(Aggregate):
     """Custom SQL aggregate to decrypt a field with public key.
 
     `PGPPublicKeySQL` provides a SQL template using pgcrypto to decrypt
@@ -25,7 +26,7 @@ class PGPPublicKeySQL(models.sql.aggregates.Aggregate):
     )
 
 
-class PGPSymmetricKeySQL(models.sql.aggregates.Aggregate):
+class PGPSymmetricKeySQL(Aggregate):
     """Custom SQL aggregate to decrypt a field with public key.
 
     `PGPSymmetricKeySQL` provides a SQL template using pgcrypto to decrypt


### PR DESCRIPTION
In django 1.8 imports has been cleaned and we were lucky to do the following in 1.7

```python
from django.db import models
models.sql.aggregates.Aggregate
```

As [\_\_init\_\_.py](https://github.com/django/django/blob/1.7.5/django/db/models/sql/__init__.py) from django.db.models.sql was loading the where.py which was loading [Aggregate](https://github.com/django/django/blob/1.7.5/django/db/models/sql/where.py#L13).