### PR TITLE
Compatibility with django1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
 env:
   matrix:
     - DJANGO='django>=1.7,<1.8'
+    - DJANGO='django>=1.8,<1.9'
     - DJANGO='--upgrade --pre django'
 matrix:
   fast_finish: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
-## Upcoming
+## v0.7.0 (Upcoming)
 
-* Fix buggy import to `Aggregate` (it affects Django 1.8 which is not supported yet)
+* Make `get_placeholder` accepts a new argument `compiler`
+* Fix buggy import to `Aggregate`
+
+**Note: these changes have been done for django > 1.8.0.**
 
 ## v0.6.4
 

--- a/pgcrypto_fields/mixins.py
+++ b/pgcrypto_fields/mixins.py
@@ -17,14 +17,14 @@ class HashMixin:
 
     `HashMixin` uses 'pgcrypto' to encrypt data in a postgres database.
     """
-    def get_placeholder(self, value=None, connection=None):
+    def get_placeholder(self, value=None, compiler=None, connection=None):
         """
         Tell postgres to encrypt this field with a hashing function.
 
         The `value` string is checked to determine if we need to hash or keep
         the current value.
 
-        `connection` is ignored here as we don't need custom operators.
+        `compiler` and `connection` is ignored here as we don't need custom operators.
         """
         if value is None or value.startswith('\\x'):
             return '%s'
@@ -60,11 +60,12 @@ class PGPMixin:
         """Value stored in the database is hexadecimal."""
         return 'bytea'
 
-    def get_placeholder(self, value=None, connection=None):
+    def get_placeholder(self, value=None, compiler=None, connection=None):
         """
         Tell postgres to encrypt this field using PGP.
 
-        `value` and `connection` are ignored here as we don't need custom operators.
+        `value`, `compiler`, and `connection` are ignored here as we don't need
+        custom operators.
         """
         return self.encrypt_sql
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,10 @@
 colour-runner==0.0.4
 coverage==3.7.1
 dj-database-url==0.3.0
-django>=1.7,<1.8
-factory-boy==2.4.1
+django>=1.8,<1.9
+factory-boy==2.5.1
 flake8-docstrings==0.2.1.post1
 flake8-import-order==0.5.3
-flake8==2.3.0
-psycopg2==2.5.4
+flake8==2.4.0
+psycopg2==2.6
 pyflakes==0.8.1


### PR DESCRIPTION
Make `django-pgcrypto-fields` compatible with `Django` v1.8