### PR TITLE
Update colour-runner to avoid no_color irritation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 -e .
-colour-runner==0.1.0
+colour-runner==0.1.1
 coverage==4.5.1
 dj-database-url==0.5.0
 django>=1.10,<2.2

--- a/tests/run.py
+++ b/tests/run.py
@@ -39,10 +39,7 @@ class TestRunner(ColourRunnerMixin, DiscoverRunner):
     """Enable colorised output."""
 
 
-test_runner = TestRunner(
-    verbosity=1,
-    no_color=False
-)
+test_runner = TestRunner(verbosity=1)
 failures = test_runner.run_tests(['tests'])
 if failures:
     sys.exit(1)


### PR DESCRIPTION
@peterfarrell I noticed that you had to add `no_color` when you updated colour-runner... that was a result of a bug, sorry about that!

I've released a new version, and this should now run without adding the extra flag :)