### PR TITLE
Add encrypted UUID fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Supported PGP public key fields are:
  - `DecimalPGPPublicKeyField`
  - `FloatPGPPublicKeyField`
  - `BooleanPGPPublicKeyField`
+ - `UUIDPGPPublicKeyField`
 
 Public key encryption creates a token generated with a public key to
 encrypt the data and a private key to decrypt it.
@@ -187,6 +188,7 @@ Supported PGP symmetric key fields are:
  - `DecimalPGPSymmetricKeyField`
  - `FloatPGPSymmetricKeyField`
  - `BooleanPGPSymmetricKeyField`
+ - `UUIDPGPSymmetricKeyField`
 
 
 Encrypt and decrypt the data with `settings.PGCRYPTO_KEY` which acts like a password.
@@ -206,6 +208,7 @@ Encrypt and decrypt the data with `settings.PGCRYPTO_KEY` which acts like a pass
 | `DecimalField`  | `DecimalPGPPublicKeyField`  | `DecimalPGPSymmetricKeyField`  |
 | `FloatField`    | `FloatPGPPublicKeyField`    | `FloatPGPSymmetricKeyField`    |
 | `BooleanField`  | `BooleanPGPPublicKeyField`  | `BooleanPGPSymmetricKeyField`  |
+| `UUIDField`     | `UUIDPGPPublicKeyField`     | `UUIDPGPSymmetricKeyField`     |
 
 **Other Django model fields are not currently supported. Pull requests are welcomed.**
 
@@ -233,6 +236,7 @@ class MyModel(models.Model):
     decimal_pgp_pub_field = fields.DecimalPGPPublicKeyField()
     float_pgp_pub_field = fields.FloatPGPPublicKeyField()
     boolean_pgp_pub_field = fields.BooleanPGPPublicKeyField()
+    uuid_pgp_pub_field = fields.UUIDPGPPublicKeyField()
     
     email_pgp_sym_field = fields.EmailPGPSymmetricKeyField()
     integer_pgp_sym_field = fields.IntegerPGPSymmetricKeyField()
@@ -243,6 +247,7 @@ class MyModel(models.Model):
     decimal_pgp_sym_field = fields.DecimalPGPSymmetricKeyField()
     float_pgp_sym_field = fields.FloatPGPSymmetricKeyField()
     boolean_pgp_sym_field = fields.BooleanPGPSymmetricKeyField()
+    uuid_pgp_sym_field = fields.UUIDPGPSymmetricKeyField()
 ```
 
 #### Encrypting

--- a/pgcrypto/fields.py
+++ b/pgcrypto/fields.py
@@ -80,6 +80,12 @@ class BooleanPGPPublicKeyField(PGPPublicKeyFieldMixin, models.BooleanField):
     cast_type = 'BOOL'
 
 
+class UUIDPGPPublicKeyField(PGPPublicKeyFieldMixin, models.UUIDField):
+    """UUID PGP public key encrypted field."""
+    encrypt_sql = PGP_PUB_ENCRYPT_SQL_WITH_NULLIF
+    cast_type = 'UUID'
+
+
 class EmailPGPSymmetricKeyField(PGPSymmetricKeyFieldMixin, models.EmailField):
     """Email PGP symmetric key encrypted field."""
 
@@ -120,6 +126,12 @@ class BooleanPGPSymmetricKeyField(PGPPublicKeyFieldMixin, models.BooleanField):
     """Boolean PGP public key encrypted field."""
     encrypt_sql = PGP_PUB_ENCRYPT_SQL_WITH_NULLIF
     cast_type = 'BOOL'
+
+
+class UUIDPGPSymmetricKeyField(PGPSymmetricKeyFieldMixin, models.UUIDField):
+    """UUID PGP symmetric key encrypted field."""
+    encrypt_sql = PGP_SYM_ENCRYPT_SQL_WITH_NULLIF
+    cast_type = 'UUID'
 
 
 class DecimalPGPPublicKeyField(DecimalPGPFieldMixin,

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,5 +1,6 @@
 from datetime import date, datetime
 from decimal import Decimal
+from uuid import uuid4
 
 import factory
 
@@ -31,6 +32,7 @@ class EncryptedModelFactory(factory.django.DjangoModelFactory):
     datetime_pgp_pub_field = datetime.now()
     decimal_pgp_pub_field = Decimal('123456.78')
     boolean_pgp_pub_field = True
+    uuid_pgp_pub_field = uuid4()
 
     email_pgp_sym_field = factory.Sequence('email{}@symmetric.key'.format)
     integer_pgp_sym_field = 43
@@ -41,6 +43,7 @@ class EncryptedModelFactory(factory.django.DjangoModelFactory):
     date_pgp_sym_field = date.today()
     datetime_pgp_sym_field = datetime.now()
     boolean_pgp_sym_field = False
+    uuid_pgp_sym_field = uuid4()
 
     fk_model = factory.SubFactory(EncryptedFKModelFactory)
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -42,6 +42,7 @@ class EncryptedModel(models.Model):
     )
     float_pgp_pub_field = fields.FloatPGPPublicKeyField(blank=True, null=True)
     boolean_pgp_pub_field = fields.BooleanPGPPublicKeyField(blank=True, null=True)
+    uuid_pgp_pub_field = fields.UUIDPGPPublicKeyField(blank=True, null=True)
 
     email_pgp_sym_field = fields.EmailPGPSymmetricKeyField(blank=True, null=True)
     integer_pgp_sym_field = fields.IntegerPGPSymmetricKeyField(blank=True, null=True)
@@ -58,6 +59,7 @@ class EncryptedModel(models.Model):
     )
     float_pgp_sym_field = fields.FloatPGPSymmetricKeyField(blank=True, null=True)
     boolean_pgp_sym_field = fields.BooleanPGPSymmetricKeyField(blank=True, null=True)
+    uuid_pgp_sym_field = fields.UUIDPGPSymmetricKeyField(blank=True, null=True)
 
     fk_model = models.ForeignKey(
         EncryptedFKModel, blank=True, null=True, on_delete=models.CASCADE

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,6 +1,7 @@
 from datetime import date, datetime
 from decimal import Decimal
 from unittest.mock import MagicMock
+from uuid import UUID
 
 from django import VERSION as DJANGO_VERSION
 from django.conf import settings
@@ -26,6 +27,8 @@ PGP_FIELDS = EMAIL_PGP_FIELDS + (
     fields.TextPGPSymmetricKeyField,
     fields.BooleanPGPPublicKeyField,
     fields.BooleanPGPSymmetricKeyField,
+    fields.UUIDPGPPublicKeyField,
+    fields.UUIDPGPSymmetricKeyField,
 )
 
 
@@ -105,6 +108,8 @@ class TestEncryptedTextFieldModel(TestCase):
             'float_pgp_sym_field',
             'boolean_pgp_pub_field',
             'boolean_pgp_sym_field',
+            'uuid_pgp_pub_field',
+            'uuid_pgp_sym_field',
             'fk_model',
         )
         self.assertCountEqual(fields, expected)
@@ -1231,6 +1236,110 @@ class TestEncryptedTextFieldModel(TestCase):
 
         self.assertEqual(
             cleaned_data['boolean_pgp_sym_field'],
+            expected
+        )
+
+    def test_uuid_pgp_pub_field(self):
+        """Test UUIDPGPPublicKeyField."""
+        expected = UUID("9bafda9e-da09-4854-a0fd-fecc11f0cebe")
+        EncryptedModelFactory.create(uuid_pgp_pub_field=expected)
+
+        instance = EncryptedModel.objects.get()
+
+        self.assertIsInstance(
+            instance.uuid_pgp_pub_field,
+            UUID
+        )
+
+        self.assertEqual(
+            instance.uuid_pgp_pub_field,
+            expected
+        )
+
+        items = EncryptedModel.objects.filter(uuid_pgp_pub_field=expected)
+
+        self.assertEqual(
+            1,
+            len(items)
+        )
+
+        items = EncryptedModel.objects.filter(
+            uuid_pgp_pub_field=UUID("db4a70c3-de7d-4399-a4a5-b6c58a09de54")
+        )
+
+        self.assertEqual(
+            0,
+            len(items)
+        )
+
+    def test_uuid_pgp_sym_field(self):
+        """Test UUIDPGPSymmetricKeyField."""
+        expected = UUID("b5cf88e6-12b6-4f01-af68-a9e5ca0f7eeb")
+        EncryptedModelFactory.create(uuid_pgp_sym_field=expected)
+
+        instance = EncryptedModel.objects.get()
+
+        self.assertIsInstance(
+            instance.uuid_pgp_sym_field,
+            UUID
+        )
+
+        self.assertEqual(
+            instance.uuid_pgp_sym_field,
+            expected
+        )
+
+        items = EncryptedModel.objects.filter(uuid_pgp_sym_field=expected)
+
+        self.assertEqual(
+            1,
+            len(items)
+        )
+
+        items = EncryptedModel.objects.filter(
+            uuid_pgp_sym_field=UUID("9b92f000-7c35-478b-acc9-e0d4c74c7d07")
+        )
+
+        self.assertEqual(
+            0,
+            len(items)
+        )
+
+    def test_pgp_public_key_uuid_form(self):
+        """Assert form field and widget for `UUIDPGPPublicKeyField` field."""
+        expected = UUID("54ced67e-4598-4797-9df9-4b814aae5cbe")
+        instance = EncryptedModelFactory.create(uuid_pgp_pub_field=expected)
+
+        payload = {
+            'uuid_pgp_pub_field': expected
+        }
+
+        form = EncryptedForm(payload, instance=instance)
+        self.assertTrue(form.is_valid())
+
+        cleaned_data = form.cleaned_data
+
+        self.assertEqual(
+            cleaned_data['uuid_pgp_pub_field'],
+            expected
+        )
+
+    def test_pgp_symmetric_key_uuid_form(self):
+        """Assert form field and widget for `UUIDPGPSymmetricKeyField` field."""
+        expected = UUID("53dd4e17-5bd7-49b2-921f-bfec43a5405b")
+        instance = EncryptedModelFactory.create(uuid_pgp_sym_field=expected)
+
+        payload = {
+            'uuid_pgp_sym_field': expected
+        }
+
+        form = EncryptedForm(payload, instance=instance)
+        self.assertTrue(form.is_valid())
+
+        cleaned_data = form.cleaned_data
+
+        self.assertEqual(
+            cleaned_data['uuid_pgp_sym_field'],
             expected
         )
 


### PR DESCRIPTION
This PR adds two new fields:

* `UUIDPGPPublicKeyField`
* `UUIDPGPSymmetricKeyField`

These are the public key / symmetric encryption equivalents to the Django standard `UUIDField`.