### PR TITLE
Fix wrong BooleanPGPSymmetricKeyField superclass and encryption SQL

### DIFF
--- a/pgcrypto/fields.py
+++ b/pgcrypto/fields.py
@@ -116,9 +116,9 @@ class DateTimePGPSymmetricKeyField(PGPSymmetricKeyFieldMixin, models.DateTimeFie
     cast_type = 'TIMESTAMPTZ'
 
 
-class BooleanPGPSymmetricKeyField(PGPPublicKeyFieldMixin, models.BooleanField):
+class BooleanPGPSymmetricKeyField(PGPSymmetricKeyFieldMixin, models.BooleanField):
     """Boolean PGP public key encrypted field."""
-    encrypt_sql = PGP_PUB_ENCRYPT_SQL_WITH_NULLIF
+    encrypt_sql = PGP_SYM_ENCRYPT_SQL_WITH_NULLIF
     cast_type = 'BOOL'
 
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1189,7 +1189,7 @@ class TestEncryptedTextFieldModel(TestCase):
             len(items)
         )
 
-        items = EncryptedModel.objects.filter(float_pgp_sym_field=True)
+        items = EncryptedModel.objects.filter(boolean_pgp_sym_field=True)
 
         self.assertEqual(
             0,


### PR DESCRIPTION
I noticed three problems with `BooleanPGPSymmetricKeyField`:

1. It inherits from `PGPPublicKeyFieldMixin` (should be `PGPSymmetricKeyFieldMixin`)
2. Its `encrypt_sql` value is `PGP_PUB_ENCRYPT_SQL_WITH_NULLIF` (should be `PGP_SYM_ENCRYPT_SQL_WITH_NULLIF`)
3. The second `filter` in `test_boolean_pgp_sym_field` is filtering by `float_pgp_sym_field` (should be `boolean_pgp_sym_field`)

This PR fixes all three.