### PR TITLE
fix batch_update

### DIFF
--- a/pgcrypto/mixins.py
+++ b/pgcrypto/mixins.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.db.models.expressions import Col
 from django.utils.functional import cached_property
+from django.db.models.functions.comparison import Cast
 
 from pgcrypto import (
     PGP_PUB_DECRYPT_SQL,
@@ -132,7 +133,17 @@ class PGPPublicKeyFieldMixin(PGPMixin):
     cast_type = 'TEXT'
 
     def get_placeholder(self, value=None, compiler=None, connection=None):
-        """Tell postgres to encrypt this field using PGP."""
+        """
+        Tell postgres to encrypt this field using PGP.
+
+        The `value` string is checked to determine if we need to hash or keep
+        the current value.
+
+        `Cast` and is ignored here as we don't need custom operators.
+        """
+        if type(value) is Cast:
+            return '%s'
+
         return self.encrypt_sql.format(get_setting(connection, 'PUBLIC_PGP_KEY'))
 
     def get_decrypt_sql(self, connection):
@@ -147,7 +158,17 @@ class PGPSymmetricKeyFieldMixin(PGPMixin):
     cast_type = 'TEXT'
 
     def get_placeholder(self, value, compiler, connection):
-        """Tell postgres to encrypt this field using PGP."""
+        """
+        Tell postgres to encrypt this field using PGP.
+
+        The `value` string is checked to determine if we need to hash or keep
+        the current value.
+
+        `Cast` and is ignored here as we don't need custom operators.
+        """
+        if type(value) is Cast:
+            return '%s'
+
         return self.encrypt_sql.format(get_setting(connection, 'PGCRYPTO_KEY'))
 
     def get_decrypt_sql(self, connection):


### PR DESCRIPTION
Fix a crashing issue when using bulk_update:

Before fix, the query for bulk_update will be cast as:
`pgp_sym_encrypt((CASE WHEN ("crm_contact"."id" = %s) THEN pgp_sym_encrypt(%s, 'xxxxxxx_pgcrypto_key') ELSE NULL END)::bytea, 'xxxxxxx_pgcrypto_key')`

Which will give error like:
`
django.db.utils.ProgrammingError: function pgp_sym_encrypt(bytea, unknown) does not exist
LINE 1: UPDATE "crm_contact" SET "phone_number_pgp" = pgp_sym_encryp...
                                                      ^
HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
`

The newly added code will check if the {value} needs to be encrypted.